### PR TITLE
Removes beta from message at top of page

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -1,6 +1,6 @@
 login: Login
 loginLink: https://v2.opensourcebrain.org
-headText: The beta release of OSBv2 is now available at
+headText: OSBv2 is now available at
 
 links: [
   {


### PR DESCRIPTION
But would be best to remove altogether:
https://github.com/OpenSourceBrain/OSB_homepage/issues/4